### PR TITLE
Add rounded corners for Redmi 7A

### DIFF
--- a/infos.json
+++ b/infos.json
@@ -55,6 +55,7 @@
             "telegram": "https://t.me/phhtreble"
         },
         "preferences": {
+            "key_misc_rounded_corners": "5",
             "key_misc_camera_timestamp": "1"
         }
     },


### PR DESCRIPTION
On Redmi 7A, rounded corners are best set on 5. Let's use this as preset !