### PR TITLE
[Nokia 8.1] Enable soundvolume effect back

### DIFF
--- a/infos.json
+++ b/infos.json
@@ -434,7 +434,6 @@
         "preferences": {
             "key_qualcomm_alternate_mediaprofile": true,
             "key_qualcomm_alternate_audiopolicy": true,
-            "key_qualcomm_disable_soundvolume_effect": true,
             "key_misc_headset_devinput": true,
             "key_misc_force_a2dp_offload_disable": true
         }


### PR DESCRIPTION
Looks like disabling it breaks BT audio at all. With enabled, earpiece is distorted only in sound settings, while on call all is ok. Further investigation needed considering this