### PR TITLE
m31: Revert automatic enable of alternate audio policy for now

### DIFF
--- a/infos.json
+++ b/infos.json
@@ -155,7 +155,6 @@
             "key_samsung_camera_ids": "true",
             "key_samsung_extra_sensors": "true",
             "key_samsung_high_brightness": "true",
-            "key_samsung_alternate_audio_policy": "true",
             "key_samsung_esco_transport_unit_size": "16"
         }
     },


### PR DESCRIPTION
For some reason, this preset breaks volume on M31 and M31s, making the volume slider unusable. Apps that use a custom volume slider like Instagram or TikTok crash when changing volume, the speaker always plays on full blast and the in-call speaker doesn't work. I will forward the issue to the bug tracker, but for now, it's better to keep this preset disabled by default.