### PR TITLE
A20: Improve fingerprint detection & fix boolean preferences

### DIFF
--- a/infos.json
+++ b/infos.json
@@ -61,7 +61,7 @@
     },
     {
         "match_property": "vendor_fp",
-        "match_value": "samsung/a20.*",
+        "match_value": "samsung/a20[^/]*/a20:.*",
         "device_name": "Samsung Galaxy A20",
 
         "maintainer": {
@@ -73,8 +73,8 @@
         },
         "preferences": {
             "key_misc_rounded_corners": "48",
-            "key_samsung_double_tap_to_wake": true,
-            "key_samsung_camera_ids": true
+            "key_samsung_double_tap_to_wake": "true",
+            "key_samsung_camera_ids": "true"
         }
     },
     {


### PR DESCRIPTION
Previous fingerprint pattern was also matching the fingerprints of the A20s and A20e. New one makes sure to only match the fingerprint of the A20.

Boolean preferences weren't being applied. Adding quotes to the value fixes this.