### PR TITLE
Realme 8 Pro preferences

### DIFF
--- a/infos.json
+++ b/infos.json
@@ -1,6 +1,25 @@
 [
     {
         "match_property": "vendor_fp",
+        "match_value": "realme/RMX3081*",
+        "device_name": "Realme 8 Pro",
+
+        "maintainer": {
+            "name": "melontini"
+        },
+        "community": {
+            "telegram": "https://t.me/phhtreble/"
+        },
+        "preferences": {
+            "key_qualcomm_alternate_audiopolicy": true,
+            "key_qualcomm_disable_stereo_voip": true,
+            "key_misc_disable_sf_gl_backpressure": true,
+            "key_misc_restart_ril": true,
+            "key_misc_dynamic_sysbta": true
+        }
+    },
+    {
+        "match_property": "vendor_fp",
         "match_value": "realme/RMX1931.*",
         "device_name": "Realme X2 Pro",
 

--- a/infos.json
+++ b/infos.json
@@ -16,6 +16,7 @@
             "key_qualcomm_disable_stereo_voip": true,
             "key_misc_disable_sf_gl_backpressure": true,
             "key_misc_restart_ril": true,
+            "key_ims_force_enable_setting": true,
             "key_misc_dynamic_sysbta": true
         }
     },

--- a/infos.json
+++ b/infos.json
@@ -12,6 +12,7 @@
         },
         "preferences": {
             "key_qualcomm_alternate_audiopolicy": true,
+            "key_qualcomm_disable_soundvolume_effect": true,
             "key_qualcomm_disable_stereo_voip": true,
             "key_misc_disable_sf_gl_backpressure": true,
             "key_misc_restart_ril": true,


### PR DESCRIPTION
All the preferences I currently have enabled on the 8 pro. I remember `key_misc_dynamic_sysbta` being false by default on older treble versions, but since preferences are downloaded, I think it's fine to add this. `key_misc_restart_ril`  is a workaround for a different VoLTE/qti issue, which I'll have to investigate later.  

btw, the format of `match_property` is a bit strange. `vendor.fingerprint` is fine, but matching the overlay with `overlay.deviceid` would be better imo.